### PR TITLE
 Fix provisioning_root_public_key variable type

### DIFF
--- a/scripts/export_header.py
+++ b/scripts/export_header.py
@@ -35,7 +35,7 @@ ${device_certificate}};
 static const uint8_t provisioning_signer_cert[] = {
 ${signer_certificate}};
 
-static const char provisioning_root_public_key[] = {
+static const uint8_t provisioning_root_public_key[] = {
 ${root_public_key}};
 """)
 

--- a/source/provision.c
+++ b/source/provision.c
@@ -145,7 +145,7 @@ int atca_provision(void)
 	printf("Comparing Device Certificate\r\n");
 	if (memcmp(provisioning_device_cert, device_der_qa, device_size))
 	{
-		printf("Signer certificate missmatch\r\n");
+		printf("Device certificate missmatch\r\n");
 
 		diff = false;
 		for (i = 0; i < device_size; i++)


### PR DESCRIPTION
provisioning_root_public_key should be uint8_t to use `atcab_write_pubkey()` and `atcacert_read_cert()`

and a small log fix