### PR TITLE
configure: use LOCK_ZONE_CONFIG

### DIFF
--- a/source/configure.c
+++ b/source/configure.c
@@ -100,7 +100,7 @@ int atca_configure(uint8_t i2c_addr)
     }
 
     /* Check the config zone lock status */
-    if (ATCA_SUCCESS != (status = atcab_is_locked(ATCA_ZONE_CONFIG, &lock)))
+    if (ATCA_SUCCESS != (status = atcab_is_locked(LOCK_ZONE_CONFIG, &lock)))
     {
         printf("Unable to get config lock status: %x\r\n", status);
         goto exit;


### PR DESCRIPTION
atcab_is_locked is intended to be used with LOCK_ZONE_x rather than ATCA_ZONE_x. In the case of the configuration zone, the defined values match, but they may not for other zones (e.g. LOCK_ZONE_DATA and ATCA_ZONE_DATA).